### PR TITLE
Always capture the stack trace.

### DIFF
--- a/error.js
+++ b/error.js
@@ -90,8 +90,7 @@ for (var status in statusCodes) {
             this.defaultMessage = defaultMsg;
             exports.HttpError.call(this, msg || status + ": " + defaultMsg, status);
 
-            if (status >= 500)
-                Error.captureStackTrace(this, arguments.callee);
+            Error.captureStackTrace(this, arguments.callee);
         };
     })(defaultMsg, status);
 


### PR DESCRIPTION
It should be up to the client of the module which stack traces to use or ignore.
