### PR TITLE
Add augment constructor

### DIFF
--- a/error.js
+++ b/error.js
@@ -1,11 +1,11 @@
 var util = require("util");
 
-exports.HttpError = function(message, code) {
+exports.HttpError = function(message, code, options) {
     Error.call(this, message);
     //Error.captureStackTrace(this, arguments.callee);
     this.message = message;
     this.code = parseInt(code, 10);
-    this.augment = null;
+    this.augment = options ? options : null;
 };
 util.inherits(exports.HttpError, Error);
 
@@ -96,12 +96,12 @@ for (var status in statusCodes) {
     var defaultMsg = statusCodes[status];
 
     var error = (function(defaultMsg, status) {
-        return function(msg) {
+        return function(msg, options) {
             if(!(this instanceof Error)) 
                 throw new Error("Must be called as constructor");
 
             this.defaultMessage = defaultMsg;
-            exports.HttpError.call(this, msg || status + ": " + defaultMsg, status);
+            exports.HttpError.call(this, msg || status + ": " + defaultMsg, status, options);
 
             if (status >= 500)
                 Error.captureStackTrace(this, arguments.callee);

--- a/error.js
+++ b/error.js
@@ -5,7 +5,7 @@ exports.HttpError = function(message, code, options) {
     //Error.captureStackTrace(this, arguments.callee);
     this.message = message;
     this.code = parseInt(code, 10);
-    this.augment = options ? options : null;
+    this.augment = options ? options.augment : null;
 };
 util.inherits(exports.HttpError, Error);
 

--- a/error_test.js
+++ b/error_test.js
@@ -18,4 +18,10 @@ describe("HttpError", function() {
             HttpError.NotFound("foo");
         }, "Must be called as constructor", "You must call as a constructor");
     });
+    
+    it("Should set augment through constructor", function() {
+        var err = new HttpError.InternalServerError("Ding Boom Bats", { augment: "foo" });
+        
+        assert.equal(err.augment, "foo");
+    });
 })


### PR DESCRIPTION
Adds augment initialisation in the constructor, so we can use it for custom errors, messages etc.
As a first scenario, we will use it to log third-party API errors to Raygun.

@mvhenten @fjakobs 
